### PR TITLE
Fix Shake Detector not working when app in background

### DIFF
--- a/lib/features/shake_detection/providers/shake_detector.dart
+++ b/lib/features/shake_detection/providers/shake_detector.dart
@@ -31,10 +31,6 @@ class ShakeDetector extends _$ShakeDetector {
       return null;
     }
 
-    // TODO: implement optimization when no book is loaded, currently it is not possible
-    // as rebuild is not triggered when app is in background and player keeps rebuilding
-    // when paused or playing
-
     // if no book is loaded, shake detection should not be enabled
     final player = ref.watch(simpleAudiobookPlayerProvider);
     player.playerStateStream.listen((event) {

--- a/lib/features/shake_detection/providers/shake_detector.g.dart
+++ b/lib/features/shake_detection/providers/shake_detector.g.dart
@@ -6,7 +6,7 @@ part of 'shake_detector.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$shakeDetectorHash() => r'e22fbd7a3b0143db3a9e2c8489749ee0dd8cd25a';
+String _$shakeDetectorHash() => r'2a380bab1d4021d05d2ae40fec964a5f33d3730c';
 
 /// See also [ShakeDetector].
 @ProviderFor(ShakeDetector)

--- a/lib/features/shake_detection/providers/shake_detector.g.dart
+++ b/lib/features/shake_detection/providers/shake_detector.g.dart
@@ -6,7 +6,7 @@ part of 'shake_detector.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$shakeDetectorHash() => r'b246be847d3ff8310f16abd683a4428dca60efdb';
+String _$shakeDetectorHash() => r'e22fbd7a3b0143db3a9e2c8489749ee0dd8cd25a';
 
 /// See also [ShakeDetector].
 @ProviderFor(ShakeDetector)

--- a/lib/features/shake_detection/providers/shake_detector.g.dart
+++ b/lib/features/shake_detection/providers/shake_detector.g.dart
@@ -6,7 +6,7 @@ part of 'shake_detector.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$shakeDetectorHash() => r'7bfbdd22f2f43ef3e3858d226d1eb78923e8114d';
+String _$shakeDetectorHash() => r'b246be847d3ff8310f16abd683a4428dca60efdb';
 
 /// See also [ShakeDetector].
 @ProviderFor(ShakeDetector)

--- a/lib/features/sleep_timer/core/sleep_timer.dart
+++ b/lib/features/sleep_timer/core/sleep_timer.dart
@@ -28,6 +28,9 @@ class SleepTimer {
   /// The timer that will pause the player
   Timer? timer;
 
+  /// is the sleep timer actively counting down
+  bool get isActive => timer != null && timer!.isActive;
+
   /// for internal use only
   /// when the timer was started
   DateTime? startedAt;

--- a/lib/features/sleep_timer/providers/sleep_timer_provider.dart
+++ b/lib/features/sleep_timer/providers/sleep_timer_provider.dart
@@ -54,7 +54,7 @@ class SleepTimer extends _$SleepTimer {
   void restartTimer() {
     state?.restartTimer();
 
-    ref.notifyListeners();
+    // ref.notifyListeners();
   }
 
   void cancelTimer() {

--- a/lib/features/sleep_timer/providers/sleep_timer_provider.dart
+++ b/lib/features/sleep_timer/providers/sleep_timer_provider.dart
@@ -54,7 +54,7 @@ class SleepTimer extends _$SleepTimer {
   void restartTimer() {
     state?.restartTimer();
 
-    // ref.notifyListeners();
+    // ref.notifyListeners(); // see https://github.com/Dr-Blank/Vaani/pull/40 for more information on why this is commented out
   }
 
   void cancelTimer() {

--- a/lib/features/sleep_timer/providers/sleep_timer_provider.g.dart
+++ b/lib/features/sleep_timer/providers/sleep_timer_provider.g.dart
@@ -6,7 +6,7 @@ part of 'sleep_timer_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$sleepTimerHash() => r'9d9f20267da91e5483151b58b7d4d7c0762c3ca7';
+String _$sleepTimerHash() => r'4f80bcc342e918c70c547b8b24790ccd88aba8c3';
 
 /// See also [SleepTimer].
 @ProviderFor(SleepTimer)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@ final appLogger = Logger('vaani');
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   // Configure the root Logger
-  Logger.root.level = Level.ALL; // Capture all logs
+  Logger.root.level = Level.FINE; // Capture all logs
   Logger.root.onRecord.listen((record) {
     // Print log records to the console
     debugPrint(

--- a/lib/settings/models/app_settings.dart
+++ b/lib/settings/models/app_settings.dart
@@ -197,12 +197,12 @@ class ShakeDetectionSettings with _$ShakeDetectionSettings {
     @Default(ShakeDirection.horizontal) ShakeDirection direction,
     @Default(5) double threshold,
     @Default(ShakeAction.resetSleepTimer) ShakeAction shakeAction,
-    @Default({ShakeDetectedFeedback.vibrate, ShakeDetectedFeedback.beep})
+    @Default({ShakeDetectedFeedback.vibrate})
     Set<ShakeDetectedFeedback> feedback,
     @Default(0.5) double beepVolume,
 
     /// the duration to wait before the shake detection is enabled again
-    @Default(Duration(seconds: 5)) Duration shakeTriggerCoolDown,
+    @Default(Duration(seconds: 2)) Duration shakeTriggerCoolDown,
 
     /// the number of shakes required to trigger the action
     @Default(2) int shakeTriggerCount,

--- a/lib/settings/models/app_settings.freezed.dart
+++ b/lib/settings/models/app_settings.freezed.dart
@@ -2633,11 +2633,10 @@ class _$ShakeDetectionSettingsImpl implements _ShakeDetectionSettings {
       this.threshold = 5,
       this.shakeAction = ShakeAction.resetSleepTimer,
       final Set<ShakeDetectedFeedback> feedback = const {
-        ShakeDetectedFeedback.vibrate,
-        ShakeDetectedFeedback.beep
+        ShakeDetectedFeedback.vibrate
       },
       this.beepVolume = 0.5,
-      this.shakeTriggerCoolDown = const Duration(seconds: 5),
+      this.shakeTriggerCoolDown = const Duration(seconds: 2),
       this.shakeTriggerCount = 2,
       this.samplingPeriod = const Duration(milliseconds: 100)})
       : _feedback = feedback;

--- a/lib/settings/models/app_settings.g.dart
+++ b/lib/settings/models/app_settings.g.dart
@@ -294,10 +294,10 @@ _$ShakeDetectionSettingsImpl _$$ShakeDetectionSettingsImplFromJson(
       feedback: (json['feedback'] as List<dynamic>?)
               ?.map((e) => $enumDecode(_$ShakeDetectedFeedbackEnumMap, e))
               .toSet() ??
-          const {ShakeDetectedFeedback.vibrate, ShakeDetectedFeedback.beep},
+          const {ShakeDetectedFeedback.vibrate},
       beepVolume: (json['beepVolume'] as num?)?.toDouble() ?? 0.5,
       shakeTriggerCoolDown: json['shakeTriggerCoolDown'] == null
-          ? const Duration(seconds: 5)
+          ? const Duration(seconds: 2)
           : Duration(
               microseconds: (json['shakeTriggerCoolDown'] as num).toInt()),
       shakeTriggerCount: (json['shakeTriggerCount'] as num?)?.toInt() ?? 2,


### PR DESCRIPTION
- app was not able to start listening to accelerometer stream once it was in background
- hence this pr avoids disposing of the shake detector by not subscribing to player events and disabling rebuilds when sleep timer is reset
- also since providers are not rebuilt when app is in background, subscribing to event stream is the only way to keep shake detector functional
- it still rebuilds on app settings changes as that can only happen in foreground