### PR TITLE
feat: Add AppImage build and generic naming for Linux artifacts

### DIFF
--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev locate
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev locate libfuse2
           # Download and install appimagetool
           wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x appimagetool-x86_64.AppImage
@@ -128,8 +128,8 @@ jobs:
           # Find and rename .deb file
           DEB_FILE=$(find dist/ -name "*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            mv "$DEB_FILE" dist/fast-forge-linux-amd64.deb
-            echo "Renamed DEB: $DEB_FILE to dist/fast-forge-linux-amd64.deb"
+            mv "$DEB_FILE" dist/vaani-linux-amd64.deb
+            echo "Renamed DEB: $DEB_FILE to dist/vaani-linux-amd64.deb"
           else
             echo "Error: .deb file not found in dist/"
             exit 1
@@ -138,8 +138,8 @@ jobs:
           # Find and rename .AppImage file
           APPIMAGE_FILE=$(find dist/ -name "*.AppImage" -type f)
           if [ -n "$APPIMAGE_FILE" ]; then
-            mv "$APPIMAGE_FILE" dist/fast-forge-linux-amd64.AppImage
-            echo "Renamed AppImage: $APPIMAGE_FILE to dist/fast-forge-linux-amd64.AppImage"
+            mv "$APPIMAGE_FILE" dist/vaani-linux-amd64.AppImage
+            echo "Renamed AppImage: $APPIMAGE_FILE to dist/vaani-linux-amd64.AppImage"
           else
             echo "Error: .AppImage file not found in dist/"
             exit 1
@@ -151,8 +151,8 @@ jobs:
         with:
           name: linux-release-artifacts
           path: |
-            dist/fast-forge-linux-amd64.deb
-            dist/fast-forge-linux-amd64.AppImage
+            dist/vaani-linux-amd64.deb
+            dist/vaani-linux-amd64.AppImage
 
   # Job 4: Create GitHub Release (NEW - runs only on tag pushes)
   create_release:

--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -111,20 +111,48 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev locate
+          # Download and install appimagetool
+          wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x appimagetool-x86_64.AppImage
+          sudo mv appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
         shell: bash
       - name: setup fastforge
         run: |
           dart pub global activate fastforge
-      - name: Build Linux AppImage
-        run: fastforge package --platform linux --targets deb
+      - name: Build Linux AppImage and deb
+        run: fastforge package --platform linux --targets deb,appimage
 
-      - name: Upload deb Artifacts
+      - name: Rename Linux Artifacts
+        run: |
+          # Find and rename .deb file
+          DEB_FILE=$(find dist/ -name "*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            mv "$DEB_FILE" dist/fast-forge-linux-amd64.deb
+            echo "Renamed DEB: $DEB_FILE to dist/fast-forge-linux-amd64.deb"
+          else
+            echo "Error: .deb file not found in dist/"
+            exit 1
+          fi
+
+          # Find and rename .AppImage file
+          APPIMAGE_FILE=$(find dist/ -name "*.AppImage" -type f)
+          if [ -n "$APPIMAGE_FILE" ]; then
+            mv "$APPIMAGE_FILE" dist/fast-forge-linux-amd64.AppImage
+            echo "Renamed AppImage: $APPIMAGE_FILE to dist/fast-forge-linux-amd64.AppImage"
+          else
+            echo "Error: .AppImage file not found in dist/"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Upload Linux Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: linux-release-artifacts
           path: |
-            dist/*/*.deb
+            dist/fast-forge-linux-amd64.deb
+            dist/fast-forge-linux-amd64.AppImage
 
   # Job 4: Create GitHub Release (NEW - runs only on tag pushes)
   create_release:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Client for [Audiobookshelf](https://github.com/advplyr/audiobookshelf) server ma
 
 *<small>Play Store version is paid if you want to support the development.</small>*
 
+### Linux
+
+[<img src="https://img.shields.io/badge/Linux%20(.deb)-Download-blue" alt="Download Linux (.deb)" height="80">](https://github.com/Dr-Blank/Vaani/releases/latest/download/fast-forge-linux-amd64.deb)
+[<img src="https://img.shields.io/badge/Linux%20(AppImage)-Download-blue" alt="Download Linux (AppImage)" height="80">](https://github.com/Dr-Blank/Vaani/releases/latest/download/fast-forge-linux-amd64.AppImage)
+
 ## Screencaps
 
 https://github.com/user-attachments/assets/2ac9ace2-4a3c-40fc-adde-55914e4cf62d

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Client for [Audiobookshelf](https://github.com/advplyr/audiobookshelf) server ma
 
 ### Linux
 
-[<img src="https://img.shields.io/badge/Linux%20(.deb)-Download-blue" alt="Download Linux (.deb)" height="80">](https://github.com/Dr-Blank/Vaani/releases/latest/download/fast-forge-linux-amd64.deb)
-[<img src="https://img.shields.io/badge/Linux%20(AppImage)-Download-blue" alt="Download Linux (AppImage)" height="80">](https://github.com/Dr-Blank/Vaani/releases/latest/download/fast-forge-linux-amd64.AppImage)
+[<img src="https://img.shields.io/badge/.deb-Download-blue" alt="Download Linux (.deb)" height="30">](https://github.com/Dr-Blank/Vaani/releases/latest/download/vaani-linux-amd64.deb)
+[<img src="https://img.shields.io/badge/AppImage-Download-blue" alt="Download Linux (AppImage)" height="30">](https://github.com/Dr-Blank/Vaani/releases/latest/download/vaani-linux-amd64.AppImage)
 
 ## Screencaps
 

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -1,0 +1,33 @@
+display_name: Vaani
+package_name: vaani
+
+maintainer:
+  name: Dr.Blank
+  email: drblankdev@gmail.com
+
+priority: optional
+
+section: x11
+
+installed_size: 75700
+
+essential: false
+
+icon: assets/icon/logo.png
+
+postuninstall_scripts:
+  - echo "Sorry to see you go."
+
+keywords:
+  - Audiobook
+  - Audiobook Player
+  - Audiobookshelf
+
+generic_name: Audiobook Player
+
+categories:
+  - Media
+  - Utility
+
+startup_notify: true
+# TODO: Review and update fields for AppImage specifics (e.g., icon, metadata).

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -26,8 +26,9 @@ keywords:
 generic_name: Audiobook Player
 
 categories:
-  - Media
-  - Utility
+  - AudioVideo
+  - Audio
+  - Player
 
 startup_notify: true
 # TODO: Review and update fields for AppImage specifics (e.g., icon, metadata).


### PR DESCRIPTION
This commit introduces the following changes to the Linux release process:

- **AppImage Support:** The GitHub Actions workflow (`flutter-ci.yaml`) now builds an AppImage alongside the existing .deb package for Linux releases. This involves:
    - Installing `appimagetool` and `locate` as part of the build dependencies.
    - Updating the `fastforge package` command to include `appimage` as a target.
    - Adding a new AppImage configuration file (`linux/packaging/appimage/make_config.yaml`), based on the existing .deb configuration. A TODO has been added to this file to prompt review for AppImage-specific fields.

- **Generic Artifact Naming:** Both the .deb and AppImage files are now renamed to generic, version-less names (`fast-forge-linux-amd64.deb` and `fast-forge-linux-amd64.AppImage`) before being uploaded as release artifacts. This makes it easier to provide stable download links.

- **README Update:** The `README.md` has been updated with direct download links to these generically named .deb and AppImage files from the latest GitHub release.